### PR TITLE
Correct weighting in enrich score of target

### DIFF
--- a/R/EnrichedHeatmap.R
+++ b/R/EnrichedHeatmap.R
@@ -52,16 +52,16 @@ enriched_score = function(mat) {
 
 		if(length(n1) && length(n2)) {
 			sum(x1 * x1_index/n1) + 
-				sum(x2 * abs(n2/2 - abs(x2_index - n2/2))) + 
+				sum(x2 * abs((n2+1)/2 - abs(x2_index - (n2+1)/2))) + 
 				sum(x3 * rev(x3_index)/n3)
 		} else if(!length(n1) && length(n2)) {
-			sum(x2 * abs(n2/2 - abs(x2_index - n2/2))) + 
+		  sum(x2 * abs((n2+1)/2 - abs(x2_index - (n2+1)/2))) + 
 				sum(x3 * rev(x3_index)/n3)
 		} else if(length(n1) && !length(n2)) {
 			sum(x1 * x1_index/n1) + 
-				sum(x2 * abs(n2/2 - abs(x2_index - n2/2)))
+		    sum(x2 * abs((n2+1)/2 - abs(x2_index - (n2+1)/2)))
 		} else {
-			sum(x2 * abs(n2/2 - abs(x2_index - n2/2)))
+		  sum(x2 * abs((n2+1)/2 - abs(x2_index - (n2+1)/2)))
 		}
 	}
 


### PR DESCRIPTION
Hi Zuguang,
correct me when I got it wrong, but as far as I understand currently the formula will calculate a weight of zero for the last window of the target (and also slightly too low for the upper half of the target. The error is small for a large number of target windows, but increases with a smaller number of target windows.